### PR TITLE
Add rate limiting functionality for password change API

### DIFF
--- a/2fa-project/src/models/RateLimit.ts
+++ b/2fa-project/src/models/RateLimit.ts
@@ -1,0 +1,41 @@
+import mongoose from 'mongoose'
+
+// Define the schema
+const RateLimitSchema = new mongoose.Schema({
+  // User ID or identifier
+  userId: {
+    type: String,
+    required: true,
+    index: true
+  },
+  // The API endpoint or action being rate limited
+  endpoint: {
+    type: String,
+    required: true
+  },
+  // Number of attempts
+  count: {
+    type: Number,
+    default: 1
+  },
+  // When the rate limit window resets
+  resetTime: {
+    type: Date,
+    required: true
+  },
+  // When this record was created
+  createdAt: {
+    type: Date,
+    default: Date.now,
+    expires: '1h' // Auto-expire old records after 1 hour
+  }
+}, {
+  // Add timestamps for when the document was created/updated
+  timestamps: true
+})
+
+// Create a compound index for userId + endpoint
+RateLimitSchema.index({ userId: 1, endpoint: 1 }, { unique: true })
+
+// Check if the model already exists to prevent model overwrite error
+export const RateLimit = mongoose.models.RateLimit || mongoose.model('RateLimit', RateLimitSchema) 

--- a/2fa-project/src/utils/rateLimiting.ts
+++ b/2fa-project/src/utils/rateLimiting.ts
@@ -1,0 +1,75 @@
+import { RateLimit } from '../models/RateLimit';
+
+/**
+ * Configuration for rate limiting
+ */
+export const RATE_LIMIT_MAX = 5; // Max 5 attempts
+export const RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes in milliseconds
+
+/**
+ * Checks if a user has exceeded the rate limit for a specific endpoint
+ * @param userId The ID of the user to check
+ * @param endpoint The name of the endpoint being rate limited
+ * @returns Promise<boolean> True if rate limited, false otherwise
+ */
+export async function isRateLimited(userId: string, endpoint: string): Promise<boolean> {
+  const now = new Date();
+  
+  try {
+    // Find or create rate limit record
+    const rateLimitRecord = await RateLimit.findOne({
+      userId: userId,
+      endpoint: endpoint
+    });
+    
+    // If no record exists or the window has expired, create/reset the record
+    if (!rateLimitRecord || now > rateLimitRecord.resetTime) {
+      // If there was an old record, update it
+      if (rateLimitRecord) {
+        rateLimitRecord.count = 1;
+        rateLimitRecord.resetTime = new Date(now.getTime() + RATE_LIMIT_WINDOW);
+        await rateLimitRecord.save();
+      } else {
+        // Create new record
+        await RateLimit.create({
+          userId: userId,
+          endpoint: endpoint,
+          count: 1,
+          resetTime: new Date(now.getTime() + RATE_LIMIT_WINDOW)
+        });
+      }
+      return false;
+    }
+    
+    // Increment count
+    rateLimitRecord.count += 1;
+    await rateLimitRecord.save();
+    
+    // Check if over limit
+    if (rateLimitRecord.count <= RATE_LIMIT_MAX) {
+      return false;
+    }
+    
+    // Over limit, deny the request
+    return true;
+  } catch (error) {
+    console.error('Rate limit check error:', error);
+    // In case of database error, allow the request (fail open for usability)
+    return false;
+  }
+}
+
+/**
+ * Resets the rate limit for a user on a specific endpoint
+ * @param userId The ID of the user
+ * @param endpoint The name of the endpoint
+ * @returns Promise<void>
+ */
+export async function resetRateLimit(userId: string, endpoint: string): Promise<void> {
+  try {
+    await RateLimit.deleteOne({ userId: userId, endpoint: endpoint });
+  } catch (error) {
+    console.error('Rate limit reset error:', error);
+    // Non-critical error, can be ignored
+  }
+} 


### PR DESCRIPTION
- Introduced RateLimit model to track user attempts for the change-password endpoint.
- Implemented rate limiting logic in the change-password API to prevent abuse by checking user attempts.
- Added utility functions for checking and resetting rate limits, enhancing security and user experience.
- Updated tests to cover rate limiting scenarios, ensuring proper handling of excessive requests.