### PR TITLE
Clear encrypted 2FA secret upon disabling and recovery code verification

### DIFF
--- a/2fa-project/src/pages/api/auth/2fa-disable.ts
+++ b/2fa-project/src/pages/api/auth/2fa-disable.ts
@@ -77,6 +77,7 @@ async function handler(req: NextApiRequest & { session: IronSession<SessionData>
   // Then immediately disable 2FA and clear all recovery codes for security
   user.twoFA.enabled = false;
   user.twoFA.recoveryCodes = [];
+  user.twoFA.secret = ''; // Clear the encrypted secret for security
 
   // Log the action using a simple note in the database
   const securityLog: SecurityLog = {

--- a/2fa-project/src/pages/api/auth/recovery-code-verify.ts
+++ b/2fa-project/src/pages/api/auth/recovery-code-verify.ts
@@ -53,6 +53,7 @@ async function handler(req: NextApiRequest & { session: IronSession<SessionData>
   user.twoFA.recoveryCodes[recoveryCodeIndex].used = true
   user.twoFA.enabled = false
   user.twoFA.recoveryCodes = []
+  user.twoFA.secret = '' // Clear the encrypted secret for security
 
   // Log security action
   const securityLog = {


### PR DESCRIPTION
- Updated the 2FA disable and recovery code verification handlers to clear the encrypted secret for enhanced security.
- Ensured that the secret is reset to an empty string when 2FA is disabled or a recovery code is used, preventing unauthorized access to sensitive information.